### PR TITLE
Enum special characters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openapi-python-generator"
-version = "0.3.4"
+version = "0.3.5"
 description = "Openapi Python Generator"
 authors = ["Marco Müllner <muellnermarco@gmail.com>"]
 license = "MIT"

--- a/src/openapi_python_generator/language_converters/python/model_generator.py
+++ b/src/openapi_python_generator/language_converters/python/model_generator.py
@@ -1,4 +1,5 @@
 import itertools
+import re
 from typing import List
 from typing import Optional
 
@@ -218,10 +219,16 @@ def generate_models(components: Components) -> List[Model]:
 
     for name, schema_or_reference in components.schemas.items():
         if schema_or_reference.enum is not None:
+            value_dict = schema_or_reference.dict()
+            regex = re.compile(r"[\s\/=\*\+]+")
+            value_dict["enum"] = [
+                re.sub(regex, "_", i) if isinstance(i, str) else f"value_{i}"
+                for i in value_dict["enum"]
+            ]
             m = Model(
                 file_name=name,
                 content=JINJA_ENV.get_template(ENUM_TEMPLATE).render(
-                    name=name, **schema_or_reference.dict()
+                    name=name, **value_dict
                 ),
                 openapi_object=schema_or_reference,
                 properties=[],


### PR DESCRIPTION
Enums now are parsed through a regex, such that special characters that can not occur in enum parameters are replaced by a `_`string.