### PR TITLE
Fix code generation when body param is of type object 

### DIFF
--- a/src/openapi_python_generator/language_converters/python/service_generator.py
+++ b/src/openapi_python_generator/language_converters/python/service_generator.py
@@ -53,6 +53,8 @@ def generate_body_param(operation: Operation) -> Union[str, None]:
             schema = media_type.media_type_schema
             if schema.type == "array":
                 return "[i.dict() for i in data]"
+            elif schema.type == "object":
+                return "data"
             else:
                 raise Exception(
                     f"Unsupported schema type for request body: {schema.type}"


### PR DESCRIPTION
Excerpt from an OpenAPI spec generated for endpoint `public async Task<IActionResult> Update([FromBody] Dictionary<string, JsonElement> settings)`:
```json
        "requestBody": {
          "description": "Key-value object.",
          "content": {
            "application/json": {
              "schema": {
                "title": "Dictionary`2",
                "type": "object",
                "additionalProperties": {
                  "title": "JsonElement"
                }
              }
            }
          }
        }
```

The param was already correctly declared as type `Dict[str, Any]` in the parameter list, but the logic for the method body did not know what to do with it (i.e., simply passing `data` to the request).