### PR TITLE
Make verify parameter configurable

### DIFF
--- a/src/openapi_python_generator/language_converters/python/templates/apiconfig.jinja2
+++ b/src/openapi_python_generator/language_converters/python/templates/apiconfig.jinja2
@@ -1,9 +1,10 @@
 {% if env_token_name is not none %}import os{% endif %}
 
-from typing import Optional
+from typing import Optional, Union
 
 class APIConfig():
     base_path: str = '{{ servers[0].url }}'
+    verify: Union[bool, str] = True
 {% if env_token_name is none %}
     _access_token : Optional[str] = None
 {% endif %}

--- a/src/openapi_python_generator/language_converters/python/templates/httpx.jinja2
+++ b/src/openapi_python_generator/language_converters/python/templates/httpx.jinja2
@@ -15,10 +15,10 @@
     query_params = {key:value for (key,value) in query_params.items() if value is not None}
 
     {% if async_client %}
-async with httpx.AsyncClient(base_url=base_path) as client:
+async with httpx.AsyncClient(base_url=base_path, verify=APIConfig.verify) as client:
         response = await client.request(
     {% else %}
-with httpx.Client(base_url=base_path) as client:
+with httpx.Client(base_url=base_path, verify=APIConfig.verify) as client:
         response = client.request(
     {% endif %}
         '{{ method }}',

--- a/src/openapi_python_generator/language_converters/python/templates/requests.jinja2
+++ b/src/openapi_python_generator/language_converters/python/templates/requests.jinja2
@@ -19,6 +19,7 @@ def {{ operation_id }}({{ params }}) -> {% if return_type.type is none or return
         f'{base_path}{path}',
         headers=headers,
         params=query_params,
+        verify=APIConfig.verify,
         {% if body_param %}
         {% if use_orjson %}
         content=orjson.dumps({{ body_param }})


### PR DESCRIPTION
For TLS connections, you may want to specify a specific certificate or disable verification altogether for testing.