### PR TITLE
Fix APIConfig Setter

### DIFF
--- a/src/openapi_python_generator/language_converters/python/templates/apiconfig.jinja2
+++ b/src/openapi_python_generator/language_converters/python/templates/apiconfig.jinja2
@@ -25,7 +25,7 @@ class APIConfig():
 {% if env_token_name is not none %}
         raise Exception("This client was generated with an environment variable for the access token. Please set the environment variable '{{ env_token_name }}' to the access token.")
 {% else %}
-        _access_token = value
+        APIConfig._access_token = value
 {% endif %}
 
 class HTTPException(Exception):

--- a/tests/test_generated_code.py
+++ b/tests/test_generated_code.py
@@ -29,7 +29,7 @@ def test_get_auth_token_without_env(model_data_with_cleanup):
     )
 
 
-def test_set_auth_token(model_data_with_cleanup):
+def test_set_auth_token():
     generate_data(test_data_path, test_result_path)
 
     _locals = locals()

--- a/tests/test_generated_code.py
+++ b/tests/test_generated_code.py
@@ -29,6 +29,22 @@ def test_get_auth_token_without_env(model_data_with_cleanup):
     )
 
 
+def test_set_auth_token(model_data_with_cleanup):
+    generate_data(test_data_path, test_result_path)
+
+    _locals = locals()
+    program = """from .test_result import APIConfig
+assert APIConfig.get_access_token() is None
+APIConfig.set_access_token('foo_bar')
+assert APIConfig.get_access_token() == 'foo_bar'
+    """
+    exec(
+        program,
+        globals(),
+        _locals,
+    )
+
+
 @pytest.mark.parametrize(
     "library, use_orjson",
     [


### PR DESCRIPTION
Fix APIConfig's  `set_access_token()` method to  update the
private `_access_token` when called.

Previously, calling "set_access_token()" was a `noop` since
 the variable assignment was all done within the local scope.

Add unit test (confirmed the unit test fails without the intervention).