### PR TITLE
Replace dots with underscores in imports

### DIFF
--- a/src/openapi_python_generator/generate_data.py
+++ b/src/openapi_python_generator/generate_data.py
@@ -97,7 +97,7 @@ def write_data(data: ConversionResult, output: Union[str, Path]) -> None:
 
     # Write the models.
     for model in data.models:
-        files.append(model.file_name)
+        files.append(model.file_name.replace(".", "_"))
         write_code(models_path / f"{model.file_name}.py", model.content)
 
     # Create models.__init__.py file containing imports to all models.

--- a/src/openapi_python_generator/language_converters/python/generator.py
+++ b/src/openapi_python_generator/language_converters/python/generator.py
@@ -29,6 +29,9 @@ def generator(
     common.set_use_orjson(use_orjson)
 
     if data.components is not None:
+        if data.components.schemas is not None:
+            data.components.schemas = {k.replace(".", "_"): v for k, v in data.components.schemas.items()}
+
         models = generate_models(data.components)
     else:
         models = []

--- a/src/openapi_python_generator/language_converters/python/model_generator.py
+++ b/src/openapi_python_generator/language_converters/python/model_generator.py
@@ -200,9 +200,6 @@ def _generate_property_from_reference(
         and name in parent_schema.required
     ) or force_required
 
-    if "issuing.transaction" in reference.ref:
-        print("debug")
-
     reference.ref = reference.ref.replace(".", "_")
     import_model = reference.ref.split("/")[-1].replace(".", "_")
 
@@ -243,8 +240,6 @@ def generate_models(components: Components) -> List[Model]:
 
     for name, schema_or_reference in components.schemas.items():
         name = name.replace(".", "_")
-        if name == 'balance_transaction':
-            print("debug")
         
         if schema_or_reference.enum is not None:
             value_dict = schema_or_reference.dict()

--- a/src/openapi_python_generator/language_converters/python/service_generator.py
+++ b/src/openapi_python_generator/language_converters/python/service_generator.py
@@ -110,6 +110,7 @@ def generate_params(operation: Operation) -> str:
         "application/json",
         "text/plain",
         "multipart/form-data",
+        "application/x-www-form-urlencoded"
     ]
 
     if operation.requestBody is not None:

--- a/src/openapi_python_generator/language_converters/python/service_generator.py
+++ b/src/openapi_python_generator/language_converters/python/service_generator.py
@@ -206,9 +206,9 @@ def generate_return_type(operation: Operation) -> OpReturnType:
     if isinstance(media_type_schema, MediaType):
         if isinstance(media_type_schema.media_type_schema, Reference):
             type_conv = TypeConversion(
-                original_type=media_type_schema.media_type_schema.ref,
-                converted_type=media_type_schema.media_type_schema.ref.split("/")[-1],
-                import_types=[media_type_schema.media_type_schema.ref.split("/")[-1]],
+                original_type=media_type_schema.media_type_schema.ref.replace(".", "_"),
+                converted_type=media_type_schema.media_type_schema.ref.split("/")[-1].replace(".", "_"),
+                import_types=[media_type_schema.media_type_schema.ref.split("/")[-1].replace(".", "_")],
             )
             return OpReturnType(
                 type=type_conv,


### PR DESCRIPTION
This PR was made in effort to make it generate a client for stripe properly using `openapi-python-generator https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json stripeclient`. Also added `"application/x-www-form-urlencoded"` as a media type

There might be a nicer solution with dots using subdirectories but this is a good fix in the meantime