### PR TITLE
Use uppercase enum keys.

### DIFF
--- a/src/openapi_python_generator/language_converters/python/templates/enum.jinja2
+++ b/src/openapi_python_generator/language_converters/python/templates/enum.jinja2
@@ -4,6 +4,6 @@ class {{ name }}(str, Enum):
     {% for enumItem in enum %}
 
     {% if enumItem is string %}
-    {{ enumItem.lower() }} = '{{ enumItem }}'{% else %}
+    {{ enumItem.upper() }} = '{{ enumItem }}'{% else %}
     value_{{ enumItem }} = {{ enumItem }}{% endif %}
     {% endfor %}


### PR DESCRIPTION
In one of our examples, we have an enumeration for US state abbreviations, which includes Indiana. This results in an entry of the form:

```py
    in = "IN",
```

which fails to compile because `in` is a reserved word.

The easiest fix I can imagine is to use upper case.