### PR TITLE
Handle null

### DIFF
--- a/src/openapi_python_generator/language_converters/python/model_generator.py
+++ b/src/openapi_python_generator/language_converters/python/model_generator.py
@@ -164,7 +164,7 @@ def type_converter(  # noqa: C901
     elif schema.type == "object":
         converted_type = pre_type + "Dict[str, Any]" + post_type
     elif schema.type is None or schema.type == "null":
-        converted_type = pre_type + "Any" + post_type
+        converted_type = pre_type + "None" + post_type
     else:
         raise TypeError(f"Unknown type: {schema.type}")
 

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -66,7 +66,7 @@ from openapi_python_generator.models import TypeConversion
         ),
         (
             Schema(type="null"),
-            TypeConversion(original_type="null", converted_type="Any"),
+            TypeConversion(original_type="null", converted_type="None"),
         ),
         (
             Schema(type="string", schema_format="uuid"),
@@ -160,7 +160,7 @@ def test_type_converter_simple(test_openapi_types, expected_python_types):
         ),
         (
             Schema(type="null"),
-            TypeConversion(original_type="null", converted_type="Any"),
+            TypeConversion(original_type="null", converted_type="None"),
         ),
         (
             Schema(type="string", schema_format="uuid"),


### PR DESCRIPTION
Related to #52, it's not clear why an explicit `null` converts to `Any`; converting to `None` seems more correct and will help `pydantic` properly parse typed object values of the form `Union[Foo | None]` (because with `Union[Foo | Any]`, it doesn't seem to know what to do.