### PR TITLE
Differentiate between a type being null and undefined/None

### DIFF
--- a/src/openapi_python_generator/language_converters/python/model_generator.py
+++ b/src/openapi_python_generator/language_converters/python/model_generator.py
@@ -163,8 +163,10 @@ def type_converter(  # noqa: C901
         converted_type = retVal + "]" + post_type
     elif schema.type == "object":
         converted_type = pre_type + "Dict[str, Any]" + post_type
-    elif schema.type is None or schema.type == "null":
+    elif schema.type == "null":
         converted_type = pre_type + "None" + post_type
+    elif schema.type is None:
+        converted_type = pre_type + "Any" + post_type
     else:
         raise TypeError(f"Unknown type: {schema.type}")
 


### PR DESCRIPTION
The changes in https://github.com/MarcoMuellner/openapi-python-generator/pull/53 seem to break genuine `any` type definitions. I'm not an openapi expert but swagger tells me that if type is not defined, i.e. undefined/None then this is considered `any`. The other case where it is defined as `null` should be correctly translated as None. 

I split the branch to allow genuine `any`s.