### PR TITLE
dont put hypens in variable names

### DIFF
--- a/src/openapi_python_generator/language_converters/python/templates/models.jinja2
+++ b/src/openapi_python_generator/language_converters/python/templates/models.jinja2
@@ -18,5 +18,5 @@ class {{ schema_name }}(BaseModel):
     """
     {% for property in properties %}
 
-    {{ property.name | replace("@","")}} : {{ property.type.converted_type | safe }} = Field(alias="{{ property.name }}" {% if not property.required %}, default = {{ property.default }} {% endif %})
+    {{ property.name | replace("@","") | replace("-","_") }} : {{ property.type.converted_type | safe }} = Field(alias="{{ property.name }}" {% if not property.required %}, default = {{ property.default }} {% endif %})
     {% endfor %}


### PR DESCRIPTION
fixes: https://github.com/MarcoMuellner/openapi-python-generator/issues/64
dont put hypens in variable names