### PR TITLE
#120 Fix parameter type checks for OpenAPI 3.0 and 3.1

### DIFF
--- a/src/openapi_python_generator/language_converters/python/service_generator.py
+++ b/src/openapi_python_generator/language_converters/python/service_generator.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 import click
 from openapi_pydantic.v3 import (
     Operation,
-    Parameter,
     PathItem,
     Reference,
     Response,
@@ -24,6 +23,7 @@ from openapi_pydantic.v3.v3_0 import (
 from openapi_pydantic.v3.v3_0 import (
     Schema as Schema30,
 )
+from openapi_pydantic.v3.v3_0.parameter import Parameter as Parameter30
 from openapi_pydantic.v3.v3_1 import (
     MediaType as MediaType31,
 )
@@ -36,6 +36,7 @@ from openapi_pydantic.v3.v3_1 import (
 from openapi_pydantic.v3.v3_1 import (
     Schema as Schema31,
 )
+from openapi_pydantic.v3.v3_1.parameter import Parameter as Parameter31
 
 from openapi_python_generator.language_converters.python import common
 from openapi_python_generator.language_converters.python.common import normalize_symbol
@@ -152,7 +153,7 @@ def generate_params(operation: Operation) -> str:
     default_params = ""
     if operation.parameters is not None:
         for param in operation.parameters:
-            if not isinstance(param, Parameter):
+            if not isinstance(param, (Parameter30, Parameter31)):
                 continue  # pragma: no cover
             converted_result = ""
             required = False
@@ -245,7 +246,7 @@ def _generate_params(
 
     params = []
     for param in operation.parameters:
-        if isinstance(param, Parameter) and param.param_in == param_in:
+        if isinstance(param, (Parameter30, Parameter31)) and param.param_in == param_in:
             param_name_cleaned = common.normalize_symbol(param.name)
             params.append(f"{param.name!r} : {param_name_cleaned}")
 
@@ -358,10 +359,13 @@ def generate_services(
                 existing_names = set()
                 if op.parameters is not None:
                     for p in op.parameters:  # type: ignore
-                        if isinstance(p, Parameter):
+                        if isinstance(p, (Parameter30, Parameter31)):
                             existing_names.add(p.name)
                 for p in path_level_params:
-                    if isinstance(p, Parameter) and p.name not in existing_names:
+                    if (
+                        isinstance(p, (Parameter30, Parameter31))
+                        and p.name not in existing_names
+                    ):
                         if op.parameters is None:
                             op.parameters = []  # type: ignore
                         op.parameters.append(p)  # type: ignore

--- a/tests/regression/test_issue_120.py
+++ b/tests/regression/test_issue_120.py
@@ -1,0 +1,36 @@
+import pytest
+from click.testing import CliRunner
+
+from openapi_python_generator.common import HTTPLibrary, library_config_dict
+from openapi_python_generator.generate_data import generate_data
+from tests.conftest import test_data_folder
+from tests.conftest import test_result_path
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Fixture for invoking command-line interfaces."""
+    return CliRunner()
+
+
+@pytest.mark.parametrize(
+    "library",
+    [HTTPLibrary.httpx, HTTPLibrary.aiohttp, HTTPLibrary.requests],
+)
+def test_issue_120(runner: CliRunner, model_data_with_cleanup, library) -> None:
+    """
+    https://github.com/MarcoMuellner/openapi-python-generator/issues/120
+    """
+    generate_data(test_data_folder / "issue_120.json", test_result_path, library)
+
+    if library_config_dict[library].include_sync:
+        assert (test_result_path / "services" / "default_service.py").exists()
+        assert (test_result_path / "services" / "default_service.py").read_text().find(
+            "language: Optional[str] = None"
+        ) != -1
+
+    if library_config_dict[library].include_async:
+        assert (test_result_path / "services" / "async_default_service.py").exists()
+        assert (
+            test_result_path / "services" / "async_default_service.py"
+        ).read_text().find("language: Optional[str] = None") != -1

--- a/tests/test_data/issue_120.json
+++ b/tests/test_data/issue_120.json
@@ -1,0 +1,53 @@
+{
+  "openapi": "3.0.0",
+    "info": {
+        "title": "New Specs",
+        "version": "1.0.0"
+    },
+  "paths": {
+    "/foo-bar": {
+      "get": {
+        "operationId": "getFooBar",
+        "parameters": [
+          {
+            "name": "language",
+            "in": "query",
+            "description": "strLanguageParam",
+            "required": false,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "default": "en",
+              "enum": [
+                "en",
+                "es",
+                "fr"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {}
+  }
+}


### PR DESCRIPTION
Replaces usage of the generic Parameter class with version-specific Parameter30 and Parameter31 classes to ensure correct type checking for parameters in OpenAPI 3.0 and 3.1 specs. Adds regression test and test data for issue #120 to verify correct handling of query parameters with enums and defaults.