### PR TITLE
Support SSE and discriminated union

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![License](https://img.shields.io/pypi/l/openapi-python-generator)][license]
 
 [![](https://img.shields.io/static/v1?label=documentation&message=enabled&color=<COLOR>)][documentation]
-[![Tests](https://github.com/MarcoMuellner/openapi-python-generator/workflows/Tests/badge.svg)][tests]
-[![Codecov](https://codecov.io/gh/MarcoMuellner/openapi-python-generator/branch/main/graph/badge.svg)][codecov]
+[![Tests](https://github.com/auth-broker/openapi-python-generator/workflows/Tests/badge.svg)][tests]
+[![Codecov](https://codecov.io/gh/auth-broker/openapi-python-generator/branch/main/graph/badge.svg)][codecov]
 
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)][pre-commit]
 [![Black](https://img.shields.io/badge/code%20style-black-000000.svg)][black]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ __Documentation:__ [here][documentation]
 You can install _Openapi Python Generator_ via [pip] from [PyPI]:
 
 ```console
-$ pip install openapi-python-generator
+$ pip install ab-openapi-python-generator
 ```
 
 ## Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "openapi-python-generator"
+name = "ab-openapi-python-generator"
 version = "v2.1.3"
 description = "Openapi Python Generator"
 authors = ["Marco Müllner <muellnermarco@gmail.com>", "Matt Coulter <mattcoul7@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "openapi-python-generator"
-version = "v2.1.2"
+version = "v2.1.3"
 description = "Openapi Python Generator"
-authors = ["Marco Müllner <muellnermarco@gmail.com>"]
+authors = ["Marco Müllner <muellnermarco@gmail.com>", "Matt Coulter <mattcoul7@gmail.com>"]
 license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/MarcoMuellner/openapi-python-generator"
-repository = "https://github.com/MarcoMuellner/openapi-python-generator"
+homepage = "https://github.com/auth-broker/openapi-python-generator"
+repository = "https://github.com/auth-broker/openapi-python-generator"
 documentation = "https://openapi-python-generator.readthedocs.io"
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -14,7 +14,7 @@ classifiers = [
 keywords = ["OpenAPI", "Generator", "Python", "async"]
 
 [tool.poetry.urls]
-Changelog = "https://github.com/MarcoMuellner/openapi-python-generator/releases"
+Changelog = "https://github.com/auth-broker/openapi-python-generator/releases"
 
 [tool.poetry.dependencies]
 python = "^3.9"

--- a/src/ab_openapi_python_generator/__init__.py
+++ b/src/ab_openapi_python_generator/__init__.py
@@ -1,0 +1,13 @@
+"""Alias package to preserve imports when distribution renamed.
+
+This package re-exports the real package located at
+`openapi_python_generator` so existing imports like
+`import ab_openapi_python_generator` continue to work.
+"""
+from openapi_python_generator import *  # noqa: F401,F403
+
+# Preserve __all__ if present on the real package
+try:
+    __all__ = getattr(__import__("openapi_python_generator"), "__all__")
+except Exception:
+    __all__ = []

--- a/src/openapi_python_generator/language_converters/python/jinja_config.py
+++ b/src/openapi_python_generator/language_converters/python/jinja_config.py
@@ -11,6 +11,7 @@ SERVICE_TEMPLATE = "service.jinja2"
 HTTPX_TEMPLATE = "httpx.jinja2"
 API_CONFIG_TEMPLATE = "apiconfig.jinja2"
 API_CONFIG_TEMPLATE_PYDANTIC_V2 = "apiconfig_pydantic_2.jinja2"
+ALIAS_UNION_TEMPLATE = "alias_union.jinja2"
 TEMPLATE_PATH = Path(__file__).parent / "templates"
 
 

--- a/src/openapi_python_generator/language_converters/python/jinja_config.py
+++ b/src/openapi_python_generator/language_converters/python/jinja_config.py
@@ -12,6 +12,7 @@ HTTPX_TEMPLATE = "httpx.jinja2"
 API_CONFIG_TEMPLATE = "apiconfig.jinja2"
 API_CONFIG_TEMPLATE_PYDANTIC_V2 = "apiconfig_pydantic_2.jinja2"
 ALIAS_UNION_TEMPLATE = "alias_union.jinja2"
+DISCRIMINATOR_ENUM_TEMPLATE = "discriminator_enum.jinja2"
 TEMPLATE_PATH = Path(__file__).parent / "templates"
 
 

--- a/src/openapi_python_generator/language_converters/python/model_generator.py
+++ b/src/openapi_python_generator/language_converters/python/model_generator.py
@@ -129,6 +129,16 @@ def _pascal_discriminator(discriminator_key: str) -> str:
     return "".join(p[:1].upper() + p[1:] for p in parts) or "Discriminator"
 
 
+def _pascal_schema_name(schema_name: str) -> str:
+    """
+    Convert a schema name like "token_issuer" into "TokenIssuer" for generated type/enum names.
+    (We don't want enum class names like `token_issuerType`.)
+    """
+    sym = common.normalize_symbol(schema_name)
+    parts = [p for p in sym.replace("-", "_").split("_") if p]
+    return "".join(p[:1].upper() + p[1:] for p in parts) or "Schema"
+
+
 def _invert_discriminator_mapping(mapping: Optional[dict]) -> Dict[str, str]:
     """
     discriminator.mapping is usually { "<disc_value>": "<$ref>" }
@@ -172,7 +182,7 @@ def _discover_discriminated_unions(
         if not discriminator_key:
             return
 
-        enum_name = f"{common.normalize_symbol(alias_name)}{_pascal_discriminator(discriminator_key)}"
+        enum_name = f"{_pascal_schema_name(alias_name)}{_pascal_discriminator(discriminator_key)}"
         ref_to_value = _invert_discriminator_mapping(getattr(disc, "mapping", None))
 
         members: List[Tuple[str, str]] = []
@@ -250,7 +260,7 @@ def _build_discriminator_bindings(components: Components) -> Dict[str, Discrimin
             continue
 
         enum_name = (
-            f"{common.normalize_symbol(schema_name)}"
+            f"{_pascal_schema_name(schema_name)}"
             f"{_pascal_discriminator(discriminator_key)}"
         )
 

--- a/src/openapi_python_generator/language_converters/python/model_generator.py
+++ b/src/openapi_python_generator/language_converters/python/model_generator.py
@@ -69,8 +69,10 @@ def _schema_is_union(schema: Schema) -> bool:
 
 
 def _alias_name_for_property(prop_name: str) -> str:
-    # "token_issuer" -> "TokenIssuer"
-    return common.normalize_symbol(prop_name)
+    # token_issuer -> TokenIssuer, foo-bar -> FooBar, etc.
+    parts = re.split(r"[^a-zA-Z0-9]+", prop_name.strip())
+    parts = [p for p in parts if p]
+    return "".join(p[:1].upper() + p[1:] for p in parts)
 
 
 def _dedupe_imports(imports: Optional[List[str]]) -> List[str]:

--- a/src/openapi_python_generator/language_converters/python/templates/alias_union.jinja2
+++ b/src/openapi_python_generator/language_converters/python/templates/alias_union.jinja2
@@ -1,0 +1,17 @@
+{# Renders ONE standalone python module that defines a named Union/Annotated alias #}
+{% if discriminator_key -%}
+from typing import Annotated, Union
+from pydantic import Field
+{% else -%}
+from typing import Union
+{% endif %}
+
+{% for imp in member_imports -%}
+{{ imp }}
+{% endfor %}
+
+{% if discriminator_key -%}
+{{ alias_name }} = Annotated[{{ union_type }}, Field(discriminator="{{ discriminator_key }}")]
+{% else -%}
+{{ alias_name }} = {{ union_type }}
+{% endif -%}

--- a/src/openapi_python_generator/language_converters/python/templates/discriminator_enum.jinja2
+++ b/src/openapi_python_generator/language_converters/python/templates/discriminator_enum.jinja2
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class {{ enum_name }}(str, Enum):
+{% for member_name, member_value in members %}
+    {{ member_name }} = "{{ member_value }}"
+{% endfor %}

--- a/src/openapi_python_generator/language_converters/python/templates/httpx.jinja2
+++ b/src/openapi_python_generator/language_converters/python/templates/httpx.jinja2
@@ -1,116 +1,126 @@
-{%  if async_client %}async {% endif %}def {{ operation_id }}(api_config_override : Optional[APIConfig] = None{% if params.strip() %}, *, {{ params.rstrip(', ') }}{% endif %}) -> {% if is_sse %}{% if async_client %}AsyncGenerator[Any, None]{% else %}Iterator[Any]{% endif %}{% else %}{% if return_type.type is none or return_type.type.converted_type is none %}None{% else %}{{ return_type.type.converted_type}}{% endif %}{% endif %}:
+{# NOTE: this template renders ONE function. It must be valid standalone python. #}
+
+{% if async_client %}async {% endif %}def {{ operation_id }}(
+    api_config_override: Optional[APIConfig] = None{% if params.strip() %}, *, {{ params.rstrip(', ') }}{% endif %}
+) -> {% if is_sse %}{% if async_client %}AsyncGenerator[Any, None]{% else %}Iterator[Any]{% endif %}{% else %}{% if return_type.type is none or return_type.type.converted_type is none %}None{% else %}{{ return_type.type.converted_type }}{% endif %}{% endif %}:
     api_config = api_config_override if api_config_override else APIConfig()
 
     base_path = api_config.base_path
     path = f'{{ path_name }}'
+
     headers = {
-        'Content-Type': 'application/json',
-        'Accept': 'text/event-stream' if is_sse else 'application/json',
-        'Authorization': f'Bearer { api_config.get_access_token() }',
+        "Content-Type": "application/json",
+{% if is_sse %}
+        "Accept": "text/event-stream",
+{% else %}
+        "Accept": "application/json",
+{% endif %}
+        "Authorization": f"Bearer { api_config.get_access_token() }",
         {{ header_params | join(',\n') | safe }}
     }
-    query_params : Dict[str,Any] = {
-    {% if query_params|length > 0 %}
-        {{ query_params | join(',\n') | safe }}
-    {% endif %}
-    }
 
-    query_params = {key:value for (key,value) in query_params.items() if value is not None}
+    query_params: Dict[str, Any] = {}
+    query_params = {key: value for (key, value) in query_params.items() if value is not None}
 
-    {# If SSE, stream lines and yield parsed events #}
-    {% if is_sse %}
+{% if is_sse %}
     import json
-    {% if async_client %}
+
+{% if async_client %}
     async with httpx.AsyncClient(base_url=base_path, verify=api_config.verify) as client:
         async with client.stream(
-            '{{ method }}',
+            "{{ method }}",
             httpx.URL(path),
             headers=headers,
             params=query_params,
-            {% if body_param %}
+{% if body_param %}
             json={{ body_param }},
-            {% endif %}
+{% endif %}
         ) as response:
             if response.status_code != {{ return_type.status_code }}:
-                raise HTTPException(response.status_code, f'{{ operation_id }} failed with status code: {response.status_code}')
+                raise HTTPException(
+                    response.status_code,
+                    f"{{ operation_id }} failed with status code: {response.status_code}",
+                )
 
             async for line in response.aiter_lines():
                 if not line:
                     continue
-                if line.startswith('data:'):
-                    payload = line[len('data:'):].strip()
+                if line.startswith("data:"):
+                    payload = line[len("data:"):].strip()
                     if not payload:
                         continue
-                    if payload == '[DONE]':
+                    if payload == "[DONE]":
                         break
                     try:
                         yield json.loads(payload)
                     except Exception:
                         yield payload
-    {% else %}
+{% else %}
     with httpx.Client(base_url=base_path, verify=api_config.verify) as client:
         with client.stream(
-            '{{ method }}',
+            "{{ method }}",
             httpx.URL(path),
             headers=headers,
             params=query_params,
-            {% if body_param %}
+{% if body_param %}
             json={{ body_param }},
-            {% endif %}
+{% endif %}
         ) as response:
             if response.status_code != {{ return_type.status_code }}:
-                raise HTTPException(response.status_code, f'{{ operation_id }} failed with status code: {response.status_code}')
+                raise HTTPException(
+                    response.status_code,
+                    f"{{ operation_id }} failed with status code: {response.status_code}",
+                )
 
             for line in response.iter_lines():
                 if not line:
                     continue
-                if line.startswith('data:'):
-                    payload = line[len('data:'):].strip()
+                if line.startswith("data:"):
+                    payload = line[len("data:"):].strip()
                     if not payload:
                         continue
-                    if payload == '[DONE]':
+                    if payload == "[DONE]":
                         break
                     try:
                         yield json.loads(payload)
                     except Exception:
                         yield payload
-    {% endif %}
-    {% else %}
-    {% if async_client %}
+{% endif %}
+
+{% else %}
+{% if async_client %}
     async with httpx.AsyncClient(base_url=base_path, verify=api_config.verify) as client:
         response = await client.request(
-    {% else %}
+{% else %}
     with httpx.Client(base_url=base_path, verify=api_config.verify) as client:
         response = client.request(
-    {% endif %}
-        '{{ method }}',
-        httpx.URL(path),
-        headers=headers,
-        params=query_params,
-        {% if body_param %}
-        {% if use_orjson %}
-        content=orjson.dumps({{ body_param }})
-        {% else %}
-        json = {{ body_param }}
-        {% endif %}
-        {% endif %}
-    )
+{% endif %}
+            "{{ method }}",
+            httpx.URL(path),
+            headers=headers,
+            params=query_params,
+{% if body_param %}
+            json={{ body_param }},
+{% endif %}
+        )
 
     if response.status_code != {{ return_type.status_code }}:
-        raise HTTPException(response.status_code, f'{{ operation_id }} failed with status code: {response.status_code}')
-    else:
-        {# Conditional body parsing: avoid calling .json() for 204 #}
-        body = None if {{ return_type.status_code }} == 204 else response.json()
-    {% endif %}
+        raise HTTPException(
+            response.status_code,
+            f"{{ operation_id }} failed with status code: {response.status_code}",
+        )
+
+    body = None if {{ return_type.status_code }} == 204 else response.json()
 
 {% if return_type.type is none or return_type.type.converted_type is none %}
     return None
 {% elif return_type.complex_type %}
-    {%- if return_type.list_type is none %}
+{% if return_type.list_type is none %}
     return {{ return_type.type.converted_type }}(**body) if body is not None else {{ return_type.type.converted_type }}()
-    {%- else %}
+{% else %}
     return [{{ return_type.list_type }}(**item) for item in body]
-    {%- endif %}
+{% endif %}
 {% else %}
     return body
+{% endif %}
 {% endif %}

--- a/src/openapi_python_generator/language_converters/python/templates/httpx.jinja2
+++ b/src/openapi_python_generator/language_converters/python/templates/httpx.jinja2
@@ -1,11 +1,11 @@
-{%  if async_client %}async {% endif %}def {{ operation_id }}(api_config_override : Optional[APIConfig] = None{% if params.strip() %}, *, {{ params.rstrip(', ') }}{% endif %}) -> {% if return_type.type is none or return_type.type.converted_type is none %}None{% else %}{{ return_type.type.converted_type}}{% endif %}:
+{%  if async_client %}async {% endif %}def {{ operation_id }}(api_config_override : Optional[APIConfig] = None{% if params.strip() %}, *, {{ params.rstrip(', ') }}{% endif %}) -> {% if is_sse %}{% if async_client %}AsyncGenerator[Any, None]{% else %}Iterator[Any]{% endif %}{% else %}{% if return_type.type is none or return_type.type.converted_type is none %}None{% else %}{{ return_type.type.converted_type}}{% endif %}{% endif %}:
     api_config = api_config_override if api_config_override else APIConfig()
 
     base_path = api_config.base_path
     path = f'{{ path_name }}'
     headers = {
         'Content-Type': 'application/json',
-        'Accept': 'application/json',
+        'Accept': 'text/event-stream' if is_sse else 'application/json',
         'Authorization': f'Bearer { api_config.get_access_token() }',
         {{ header_params | join(',\n') | safe }}
     }
@@ -17,11 +17,70 @@
 
     query_params = {key:value for (key,value) in query_params.items() if value is not None}
 
+    {# If SSE, stream lines and yield parsed events #}
+    {% if is_sse %}
+    import json
     {% if async_client %}
-async with httpx.AsyncClient(base_url=base_path, verify=api_config.verify) as client:
+    async with httpx.AsyncClient(base_url=base_path, verify=api_config.verify) as client:
+        async with client.stream(
+            '{{ method }}',
+            httpx.URL(path),
+            headers=headers,
+            params=query_params,
+            {% if body_param %}
+            json={{ body_param }},
+            {% endif %}
+        ) as response:
+            if response.status_code != {{ return_type.status_code }}:
+                raise HTTPException(response.status_code, f'{{ operation_id }} failed with status code: {response.status_code}')
+
+            async for line in response.aiter_lines():
+                if not line:
+                    continue
+                if line.startswith('data:'):
+                    payload = line[len('data:'):].strip()
+                    if not payload:
+                        continue
+                    if payload == '[DONE]':
+                        break
+                    try:
+                        yield json.loads(payload)
+                    except Exception:
+                        yield payload
+    {% else %}
+    with httpx.Client(base_url=base_path, verify=api_config.verify) as client:
+        with client.stream(
+            '{{ method }}',
+            httpx.URL(path),
+            headers=headers,
+            params=query_params,
+            {% if body_param %}
+            json={{ body_param }},
+            {% endif %}
+        ) as response:
+            if response.status_code != {{ return_type.status_code }}:
+                raise HTTPException(response.status_code, f'{{ operation_id }} failed with status code: {response.status_code}')
+
+            for line in response.iter_lines():
+                if not line:
+                    continue
+                if line.startswith('data:'):
+                    payload = line[len('data:'):].strip()
+                    if not payload:
+                        continue
+                    if payload == '[DONE]':
+                        break
+                    try:
+                        yield json.loads(payload)
+                    except Exception:
+                        yield payload
+    {% endif %}
+    {% else %}
+    {% if async_client %}
+    async with httpx.AsyncClient(base_url=base_path, verify=api_config.verify) as client:
         response = await client.request(
     {% else %}
-with httpx.Client(base_url=base_path, verify=api_config.verify) as client:
+    with httpx.Client(base_url=base_path, verify=api_config.verify) as client:
         response = client.request(
     {% endif %}
         '{{ method }}',
@@ -42,6 +101,7 @@ with httpx.Client(base_url=base_path, verify=api_config.verify) as client:
     else:
         {# Conditional body parsing: avoid calling .json() for 204 #}
         body = None if {{ return_type.status_code }} == 204 else response.json()
+    {% endif %}
 
 {% if return_type.type is none or return_type.type.converted_type is none %}
     return None

--- a/src/openapi_python_generator/language_converters/python/templates/models.jinja2
+++ b/src/openapi_python_generator/language_converters/python/templates/models.jinja2
@@ -20,5 +20,5 @@ class {{ schema_name }}(BaseModel):
     """
     {% for property in properties %}
 
-    {{ property.name | normalize_symbol }} : {{ property.type.converted_type | safe }} = Field(alias="{{ property.name }}" {% if not property.required %}, default = {{ property.default }} {% endif %})
+    {{ property.name | normalize_symbol }} : {{ property.type.converted_type | safe }} = Field(alias="{{ property.name }}"{% if property.default is not none %}, default = {{ property.default }}{% endif %})
     {% endfor %}

--- a/src/openapi_python_generator/language_converters/python/templates/models_pydantic_2.jinja2
+++ b/src/openapi_python_generator/language_converters/python/templates/models_pydantic_2.jinja2
@@ -24,5 +24,5 @@ class {{ schema_name }}(BaseModel):
     }
     {% for property in properties %}
 
-    {{ property.name | normalize_symbol }} : {{ property.type.converted_type | safe }} = Field(validation_alias="{{ property.name }}" {% if not property.required %}, default = {{ property.default }} {% endif %})
+    {{ property.name | normalize_symbol }} : {{ property.type.converted_type | safe }} = Field(validation_alias="{{ property.name }}"{% if property.default is not none %}, default = {{ property.default }}{% endif %})
     {% endfor %}

--- a/src/openapi_python_generator/models.py
+++ b/src/openapi_python_generator/models.py
@@ -61,6 +61,7 @@ class ServiceOperation(BaseModel):
     path_name: str
     body_param: Optional[str] = None
     method: str
+    is_sse: bool = False
     use_orjson: bool = False
 
 


### PR DESCRIPTION
# Disclaimer

Hey, I'm using for this for my own purpose to support sse and discriminated union.

Sorry it is not the cleanest, as my focus is just getting the generator to work.

I have stuck to using jinja2 files for all code gen, but there are a lot of new functions, mainly in the model_generator.py which makes the module really messy and hard to follow.

If someone wants to actually productionalize these features, then maybe this PR is a good starting point, and would need to do a bit if refactor.

I also used ChatGPT / Copilot to make most of these code changes.

---

# Summary

- Add's support for sse / event-stream endpoints
- Add's support for discriminated unions

---

# Example code gen

## OpenAPI input (relevant excerpts)

### Discriminated union on request models

```json
"AuthenticateRequest": {
  "type": "object",
  "required": ["token_issuer"],
  "properties": {
    "token_issuer": {
      "oneOf": [
        { "$ref": "#/components/schemas/PKCEOAuth2TokenIssuer" },
        { "$ref": "#/components/schemas/OAuth2TokenIssuer" },
        { "$ref": "#/components/schemas/TemplateTokenIssuer" }
      ],
      "discriminator": {
        "propertyName": "type",
        "mapping": {
          "OAUTH2": "#/components/schemas/OAuth2TokenIssuer",
          "PKCE": "#/components/schemas/PKCEOAuth2TokenIssuer",
          "TEMPLATE": "#/components/schemas/TemplateTokenIssuer"
        }
      }
    }
  }
}
```

### Member schemas already define discriminator `const` + default

```json
"PKCEOAuth2TokenIssuer": {
  "type": "object",
  "properties": {
    "type": { "type": "string", "const": "PKCE", "default": "PKCE" }
  }
},
"OAuth2TokenIssuer": {
  "type": "object",
  "properties": {
    "type": { "type": "string", "const": "OAUTH2", "default": "OAUTH2" }
  }
}
```

(And similarly for `TemplateTokenIssuer` etc.)

---

## Before (generated Python)

### Request model: plain Union (no discriminator alias type)

```py
class AuthenticateRequest(BaseModel):
    token_issuer: Union[PKCEOAuth2TokenIssuer, OAuth2TokenIssuer, TemplateTokenIssuer] = Field(
        validation_alias="token_issuer"
    )
```

### Union members: discriminator field not enforced

```py
class PKCEOAuth2TokenIssuer(BaseModel):
    ...
    type: Optional[str] = Field(validation_alias="type", default=None)
```

---

## After (generated Python)

### Central alias module for the discriminated union

```py
# TokenIssuer.py
from typing import Annotated, Union
from pydantic import Field

from .OAuth2TokenIssuer import OAuth2TokenIssuer
from .PKCEOAuth2TokenIssuer import PKCEOAuth2TokenIssuer
from .TemplateTokenIssuer import TemplateTokenIssuer

TokenIssuer = Annotated[
    Union[PKCEOAuth2TokenIssuer, OAuth2TokenIssuer, TemplateTokenIssuer],
    Field(discriminator="type"),
]
```

### Request model imports the alias

```py
from .TokenIssuer import TokenIssuer

class AuthenticateRequest(BaseModel):
    token_issuer: TokenIssuer = Field(validation_alias="token_issuer")
```

### Generated discriminator enum (PascalCase schema + discriminator key)

```py
# TokenIssuerType.py
from enum import Enum

class TokenIssuerType(str, Enum):
    PKCE = "PKCE"
    OAUTH2 = "OAUTH2"
    TEMPLATE = "TEMPLATE"
```

### Union members now have strict discriminator typing + default

```py
from typing import Literal
from .TokenIssuerType import TokenIssuerType

class PKCEOAuth2TokenIssuer(BaseModel):
    ...
    type: Literal[TokenIssuerType.PKCE] = Field(
        validation_alias="type",
        default=TokenIssuerType.PKCE,
    )
```